### PR TITLE
Update docker-img-push.yaml

### DIFF
--- a/.github/workflows/docker-img-push.yaml
+++ b/.github/workflows/docker-img-push.yaml
@@ -1,6 +1,6 @@
 name: Build and Push Docker Image
 permissions:
-  contents: read
+  contents: write
   packages: write
   actions: write
 on:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/docker-img-push.yaml` file. The change updates the `contents` permission from `read` to `write` to allow for write access during the Docker image build and push process.